### PR TITLE
Small fixes to the generators

### DIFF
--- a/src/CodeStreams/PhpCodeStream.php
+++ b/src/CodeStreams/PhpCodeStream.php
@@ -218,7 +218,7 @@ class PhpCodeStream
             }
             // adding other annotations
             foreach ($docBlock->getRemainingAnnotations() as $annotation) {
-                $code[] = '@'.$annotation['annotation'].' '.$annotation['text'];
+                $code[] = trim('@'.$annotation['annotation'].' '.$annotation['text']);
             }
         }
 

--- a/src/CodeStreams/PhpCodeStream.php
+++ b/src/CodeStreams/PhpCodeStream.php
@@ -220,6 +220,7 @@ class PhpCodeStream
             }
             // adding other annotations
             foreach ($docBlock->getRemainingAnnotations() as $annotation) {
+                // Sometimes an annotation has no text, so the rtrim is to remove any possible trailing spaces.
                 $code[] = trim('@'.$annotation['annotation'].' '.$annotation['text']);
             }
         }

--- a/src/CodeStreams/PhpCodeStream.php
+++ b/src/CodeStreams/PhpCodeStream.php
@@ -73,7 +73,9 @@ class PhpCodeStream
      */
     public function prefixLines(string $prefix, string $code): string
     {
-        return $prefix.str_replace(PHP_EOL, PHP_EOL.$prefix, $code);
+        // The preg_replace is to remove trailing spaces on empty comment lines. The rtrim is to remove lines that consist
+        // of only spaces.
+        return rtrim($prefix.str_replace(PHP_EOL, PHP_EOL.$prefix, preg_replace('/\*\s*'.PHP_EOL.'/', '*'.PHP_EOL, $code)));
     }
 
     protected function appendCode(string $code)

--- a/src/Generators/AbstractFileGenerator.php
+++ b/src/Generators/AbstractFileGenerator.php
@@ -117,10 +117,8 @@ abstract class AbstractFileGenerator extends AbstractGenerator
 
         // namespace
         if ($model->getNamespace()) {
-            $this->stream->eol()->code('namespace '.$model->getNamespace().';')->eol();
+            $this->stream->code('namespace '.$model->getNamespace().';')->eol();
         }
-
-        $this->stream->eol();
 
         // uses
         foreach ($model->getUses() as $use) {
@@ -129,7 +127,9 @@ abstract class AbstractFileGenerator extends AbstractGenerator
                 $this->stream->code('use '.$use.';');
             }
         }
-        $this->stream->eol();
+        if ($model->getUses()->count()) {
+            $this->stream->eol(); // Only output a blank line if we outputted any "use" statements.
+        }
         $this->stream->docBlockComment($this->buildDocBlock($model));
         $this->stream->code($this->buildSignature($model));
     }

--- a/src/Generators/AbstractFileGenerator.php
+++ b/src/Generators/AbstractFileGenerator.php
@@ -87,7 +87,7 @@ abstract class AbstractFileGenerator extends AbstractGenerator
     abstract function buildSignature($model): string;
 
     /**
-     * Building the docblock for a File ( class, trait or interface level
+     * Building the docblock for a File (class, trait or interface level)
      *
      * @param AbstractFileModel $model
      *
@@ -95,7 +95,7 @@ abstract class AbstractFileGenerator extends AbstractGenerator
      */
     protected function buildDocBlock(AbstractFileModel $model): DocBlockModel
     {
-        $docBlock = new DocBlockModel('class '.$model->getName().PHP_EOL.$model->getDescription());
+        $docBlock = new DocBlockModel('class '.$model->getName().($model->getDescription()?PHP_EOL.$model->getDescription():''));
 
         foreach ($model->getAnnotations() as $annotation) {
             $docBlock->addAnnotation($annotation['annotation'], $annotation['text']);
@@ -105,7 +105,7 @@ abstract class AbstractFileGenerator extends AbstractGenerator
     }
 
     /**
-     * Building the File heading ( defining the namespace, usages, docblock and the signature
+     * Building the File heading (defining the namespace, usages, docblock and the signature)
      *
      * @param AbstractFileModel $model
      */


### PR DESCRIPTION
The generated files sometimes had too many blank lines, or block comments with trailing empty lines, causing our pipeline to spend time removing them and creating an additional commit.

This update stops those things.

Also, there were closing brackets missing in a couple of the comments!