### PR TITLE
Don't generate rendundant "class ClassName" docblocks

### DIFF
--- a/src/CodeStreams/PhpCodeStream.php
+++ b/src/CodeStreams/PhpCodeStream.php
@@ -233,7 +233,9 @@ class PhpCodeStream
             $code[] = '@return '.$docBlock->getReturnAnnotation();
         }
 
-        $this->appendCode('/**'.PHP_EOL.$this->prefixLines(' * ', implode(PHP_EOL, $code)).PHP_EOL.' */');
+        if (!empty($code)) {
+            $this->appendCode('/**'.PHP_EOL.$this->prefixLines(' * ', implode(PHP_EOL, $code)).PHP_EOL.' */');
+        }
 
         return $this;
     }

--- a/src/Generators/AbstractFileGenerator.php
+++ b/src/Generators/AbstractFileGenerator.php
@@ -95,7 +95,7 @@ abstract class AbstractFileGenerator extends AbstractGenerator
      */
     protected function buildDocBlock(AbstractFileModel $model): DocBlockModel
     {
-        $docBlock = new DocBlockModel('class '.$model->getName().($model->getDescription()?PHP_EOL.$model->getDescription():''));
+        $docBlock = new DocBlockModel();
 
         foreach ($model->getAnnotations() as $annotation) {
             $docBlock->addAnnotation($annotation['annotation'], $annotation['text']);

--- a/src/Generators/AbstractFileGenerator.php
+++ b/src/Generators/AbstractFileGenerator.php
@@ -95,7 +95,7 @@ abstract class AbstractFileGenerator extends AbstractGenerator
      */
     protected function buildDocBlock(AbstractFileModel $model): DocBlockModel
     {
-        $docBlock = new DocBlockModel();
+        $docBlock = new DocBlockModel($model->getDescription());
 
         foreach ($model->getAnnotations() as $annotation) {
             $docBlock->addAnnotation($annotation['annotation'], $annotation['text']);


### PR DESCRIPTION
Currently it generates this:

```
/**
 * class ClassName
 */
class ClassName extends Something 
{
```

The docblock is useless as all it contains is the class name we already know.
